### PR TITLE
Hud Upgrade - Larger Power Number

### DIFF
--- a/tourjs-react/src/Components/InRaceView.scss
+++ b/tourjs-react/src/Components/InRaceView.scss
@@ -72,6 +72,14 @@ $minimapRowHeight: 12vh;
     height: $minimapRowHeight;
     background-color: rgba(0,0,0,1);
   }
+  &__StatusExtra-Container {
+    position: absolute;
+    top: 0px;
+    right: 0px;
+    width: 7vw;
+    height: 7vh;
+    background-color: rgba(0,0,0,0.45);
+  }
   &__Minimap-Container {
     position: absolute;
     right: 0px;

--- a/tourjs-react/src/Components/InRaceView.tsx
+++ b/tourjs-react/src/Components/InRaceView.tsx
@@ -16,7 +16,7 @@ import { updateIf } from "typescript";
 import { DistanceDisplay, TimeDisplay } from "./PreRaceView";
 import { assert2 } from "../tourjs-shared/Utils";
 import { InRaceLeaderboard } from "./InRaceViewLeaderboard";
-import { InRaceViewStatus } from "./InRaceViewStatus";
+import { InRaceViewStatus, InRaceViewStatusExtra } from "./InRaceViewStatus";
 import { AppPlayerContextType } from "../ContextPlayer";
 import { AppPlayerContextInstance } from "../index-contextLoaders";
 import { RaceMapLive } from "./RaceMapLive";
@@ -91,14 +91,17 @@ export default function InRaceView(props:{raceState:RaceState}) {
 
   return <div className={`InRaceView__Container ${following && 'Following'} ${beingFollowed && 'BeingFollowed'}`}>
       <canvas ref={canvasRef}  className="InRaceView__Canvas"/>
-      <div className="InRaceView__Status-Container">
-        {props.raceState && <InRaceViewStatus raceState={props.raceState} tmNow={tm} playerContext={playerContext} />}
-      </div>
-      <div className="InRaceView__Minimap-Container">
-        {props.raceState && <RaceMapLive className="" raceState={props.raceState} tmNow={tm} playerContext={playerContext} />}
-      </div>
-      <div className="InRaceView__Leaderboard-Container">
-        {props.raceState && <InRaceLeaderboard frames={frames} raceState={props.raceState} tmNow={tm} />}
+        <div className="InRaceView__Status-Container">
+          {props.raceState && <InRaceViewStatus raceState={props.raceState} tmNow={tm} playerContext={playerContext} />}
+        </div>
+        <div className="InRaceView__StatusExtra-Container">
+          {props.raceState && <InRaceViewStatusExtra raceState={props.raceState} tmNow={tm} playerContext={playerContext} />}
+        </div>
+        <div className="InRaceView__Minimap-Container">
+          {props.raceState && <RaceMapLive className="" raceState={props.raceState} tmNow={tm} playerContext={playerContext} />}
+        </div>
+        <div className="InRaceView__Leaderboard-Container">
+          {props.raceState && <InRaceLeaderboard frames={frames} raceState={props.raceState} tmNow={tm} />}
       </div>
     </div>
 }

--- a/tourjs-react/src/Components/InRaceViewStatus.scss
+++ b/tourjs-react/src/Components/InRaceViewStatus.scss
@@ -13,25 +13,25 @@
 
 .InRaceViewStatus {
   &__Outer-Container {
-    display: flex;
-    flex-direction: row;
-    //font-size: 100%;
+    display: grid;
+    row-gap: 1%;
   }
-  &__Container {
-    flex: 1 1 0px;
-    display: flex;
-    flex-direction: column;
-  }
-  &__TextAlignRight {
-    text-align:right;
-    flex: 1 1 auto;
-  }
-  &__InfoChunk {
+  &__Wattage {
     color: white;
     flex: 1 1 0px;
-    font-size: 3vh;
+    font-size: 3vw;
     text-align: left;
-    padding-left: 10%;
+    padding-left: 5%;
+    overflow: visible;
+    z-index: 1;
+    flex: 1 1 auto;
+  }
+  &__Hill {
+    color: white;
+    flex: 1 1 0px;
+    font-size: 2.5vh;
+    text-align: bottom;
+    padding-left: 5%;
     overflow: visible;
     z-index: 1;
     flex: 1 1 auto;
@@ -45,12 +45,26 @@
     }
     
   }
-  &__RightSide {
-    text-align: right;
+  &__Progress {
+    border-radius: 10px;
+    width: 80%;
+    height: 2vh;
   }
+  &__Bpm {
+    color: white;
+    flex: 1 1 0px;
+    font-size: 3vh;
+    text-align: left;
+    padding-left: 10%;
+    overflow: visible;
+    z-index: 1;
+    flex: 1 1 auto;
+  }
+
+  
   &__Connect {
     text-shadow: white 0px 0px 6px;
-
+    justify-self: right;
     animation: none;
     &.NoPower {
       animation-name: PulseBlueRed;
@@ -67,16 +81,14 @@
     font-size: 2.5vh;
     text-align: center;
   }
-  &__Progress {
-    width: 100%;
-    height: 3vh;
-  }
+  
   &__Handicap {
     flex: 1 1 auto;
     overflow: hidden;
-    font-size: 1.2vw;
+    font-size: 2vh;
+    text-align: right;
     color: rgba(255,255,255,0.3);
-    display: inline-block;
+    display: inline;
     border-radius: 0.4vh;
     padding: 2px;
     transition: color 0.5s, background-color 0.5s;

--- a/tourjs-react/src/Components/InRaceViewStatus.tsx
+++ b/tourjs-react/src/Components/InRaceViewStatus.tsx
@@ -55,6 +55,72 @@ function ProgressCanvass(props:{pct:number, className:string}) {
 
 export function InRaceViewStatus(props:{raceState:RaceState, tmNow:number, playerContext:AppPlayerContextType}) {
 
+  const localUser = props.raceState.getLocalUser();
+
+  let wattage;
+  let draftWatts;
+  let percentHill;
+  let bpm;
+  let pctUp;
+
+
+  if(localUser) {
+    
+    const power = localUser.getLastPower();
+    
+
+    wattage = `${power.toFixed(0)}⚡`;
+
+    const savings = localUser.getLastWattsSaved();
+    if(savings && savings.watts > 0) {
+      draftWatts = `+${savings.watts.toFixed(0)}`;
+    }
+
+    const slope = localUser.getLastSlopeInWholePercent();
+    percentHill = slope.toFixed(1) + '%';
+
+    const hillStats = props.raceState.getMap().getHillStatsAtDistance(localUser.getDistance());
+    console.log("Hillstats = ", hillStats);
+    if(hillStats && hillStats.endElev > hillStats.startElev) {
+      pctUp = (localUser.getLastElevation() - hillStats.startElev) / (hillStats.endElev - hillStats.startElev);
+    }
+
+    const hrm = localUser.getLastHrm(props.tmNow);
+    if(hrm) {
+      bpm = `${hrm.toFixed(0)}❤`
+    } else {
+      bpm = `--❤`;
+    }
+  }
+
+
+
+  return <><div className="InRaceViewStatus__Outer-Container">
+    
+      {wattage && <div className="InRaceViewStatus__Wattage">
+        {wattage}
+        {draftWatts && <span className="InRaceViewStatus__Draft">({draftWatts})</span>}
+      </div>}
+      {percentHill && <div className="InRaceViewStatus__Hill Flex">
+        {percentHill}
+        <span className="InRaceViewStatus__Hill FlexGrow">{pctUp && <ProgressCanvass pct={pctUp} className="InRaceViewStatus__Progress"/>}</span>
+      </div>}
+      {false && bpm && <div className="InRaceViewStatus__Bpm">
+        {bpm}
+      </div>}
+
+  </div>
+  
+  </>
+}
+
+
+
+
+
+//This function is used to display the PM connect button and FTP in the top right ciorner of the screen
+export function InRaceViewStatusExtra(props:{raceState:RaceState, tmNow:number, playerContext:AppPlayerContextType}) {
+
   let [tmOfLastNonzero, setTmOfLastNonzero] = useState<number>(0);
   let [lastHandicap, setLastHandicap] = useState<number>(0);
   let [tmStartDisplayHandicap, setTmStartDisplayHandicap] = useState<number>(0);
@@ -64,15 +130,8 @@ export function InRaceViewStatus(props:{raceState:RaceState, tmNow:number, playe
   
   const localUser = props.raceState.getLocalUser();
 
-
-
-
-  let wattage;
-  let draftWatts;
-  let percentHill;
-  let bpm;
   let handicap;
-  let pctUp;
+
 
   useEffect(() => {
     setIsDoublingPower(props.playerContext.doublePower);
@@ -93,29 +152,6 @@ export function InRaceViewStatus(props:{raceState:RaceState, tmNow:number, playe
         setTmOfLastNonzero(new Date().getTime());
       }
     }
-
-    wattage = `${power.toFixed(0)}⚡`;
-
-    const savings = localUser.getLastWattsSaved();
-    if(savings && savings.watts > 0) {
-      draftWatts = `+${savings.watts.toFixed(0)}⚡`;
-    }
-
-    const slope = localUser.getLastSlopeInWholePercent();
-    percentHill = slope.toFixed(1) + '%';
-
-    const hillStats = props.raceState.getMap().getHillStatsAtDistance(localUser.getDistance());
-    console.log("Hillstats = ", hillStats);
-    if(hillStats && hillStats.endElev > hillStats.startElev) {
-      pctUp = (localUser.getLastElevation() - hillStats.startElev) / (hillStats.endElev - hillStats.startElev);
-    }
-
-    const hrm = localUser.getLastHrm(props.tmNow);
-    if(hrm) {
-      bpm = `${hrm.toFixed(0)}❤`
-    } else {
-      bpm = `--❤`;
-    }
   }
 
   const onConnectPm = async () => {
@@ -134,33 +170,16 @@ export function InRaceViewStatus(props:{raceState:RaceState, tmNow:number, playe
   let handiDisplay:boolean = tmNow < tmStartDisplayHandicap + 10000;
 
   return <><div className="InRaceViewStatus__Outer-Container">
-    <div className="InRaceViewStatus__LeftSide InRaceViewStatus__Container">
-      {wattage && <div className="InRaceViewStatus__InfoChunk">
-        {wattage}
-        {draftWatts && <span className="InRaceViewStatus__Draft">({draftWatts})</span>}
-      </div>}
-      {percentHill && <div className="InRaceViewStatus__InfoChunk Flex">
-        {percentHill}
-        <span className="InRaceViewStatus__InfoChunk FlexGrow">{pctUp && <ProgressCanvass pct={pctUp} className="InRaceViewStatus__Progress"/>}</span>
-      </div>}
-      {false && bpm && <div className="InRaceViewStatus__InfoChunk">
-        {bpm}
-      </div>}
+    {localUser && localUser.getDistance() <= 1000 && (
+      <div className={`InRaceViewStatus__Connect SmallButton`} onClick={() => on2XPower()}>
+        {isDoublingPower && ("2x") || ("1/2")}
+      </div>
+    )}
+    <div className={`InRaceViewStatus__Connect ${connectClass} SmallButton`} onClick={() => onConnectPm()}>
+      🔌
     </div>
-    <div className="InRaceViewStatus__RightSide InRaceViewStatus__Container">
-      {localUser && localUser.getDistance() <= 1000 && (
-        <div className={`InRaceViewStatus__Connect SmallButton`} onClick={() => on2XPower()}>
-          {isDoublingPower && ("2x") || ("1/2")}
-        </div>
-      )}
-      <div className="InRaceViewStatus__TextAlignRight">
-        <div className={`InRaceViewStatus__Connect ${connectClass} SmallButton`} onClick={() => onConnectPm()}>
-          🔌
-        </div>
-      </div>
-      <div className={`InRaceViewStatus__Handicap ${handicap && handiDisplay && 'Shown'}`}>
-      FTP: {handicap.toFixed(0)}⚡
-      </div>
+    <div className={`InRaceViewStatus__Handicap ${handicap && handiDisplay && 'Shown'}`}>
+    FTP: {handicap.toFixed(0)}⚡
     </div>
   </div>
   

--- a/tourjs-react/src/Components/InRaceViewStatus.tsx
+++ b/tourjs-react/src/Components/InRaceViewStatus.tsx
@@ -53,6 +53,11 @@ function ProgressCanvass(props:{pct:number, className:string}) {
   return <canvas id={myId} className={`ProgressCanvas__Canvas ${props.className}`}></canvas>
 }
 
+
+
+//Bottom Left Status:
+//Wattage
+//Hillslope
 export function InRaceViewStatus(props:{raceState:RaceState, tmNow:number, playerContext:AppPlayerContextType}) {
 
   const localUser = props.raceState.getLocalUser();
@@ -118,7 +123,9 @@ export function InRaceViewStatus(props:{raceState:RaceState, tmNow:number, playe
 
 
 
-//This function is used to display the PM connect button and FTP in the top right ciorner of the screen
+//Top right Status:
+//PM Connect
+//FTP
 export function InRaceViewStatusExtra(props:{raceState:RaceState, tmNow:number, playerContext:AppPlayerContextType}) {
 
   let [tmOfLastNonzero, setTmOfLastNonzero] = useState<number>(0);


### PR DESCRIPTION
Hud Upgrade - made power numbers larger in hud

To make room for the larger power numbers, I moved the PM connect button and FTP to the top right of the screen
To do this, I split up the function `InRaceViewStatus` found in `tourjs-react -> src -> components -> InRaceViewStatus.tsx` into two separate functions:

1. `InRaceViewStatus`
Bottom left of screen
Displays Power and Hillslope

2. `InRaceViewStatusExtra`
Top right of screen
Displays PM connect button and FTP


Besides the above large change, there's just some small CSS things (like rounding the corners of the hill climb percent bar)
![pull request](https://github.com/arthare/btweb2/assets/47436547/da655dd5-7e1e-4261-9946-f4a7f4e0333a)
